### PR TITLE
Publish on legacy OSSRH host

### DIFF
--- a/datafusion-java/build.gradle
+++ b/datafusion-java/build.gradle
@@ -147,8 +147,8 @@ publishing {
     repositories {
         maven {
             name = "Sonatype"
-            def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             credentials {
                 username = findProperty('ossrhUsername') ?: System.getenv("MAVEN_USERNAME")


### PR DESCRIPTION
Our group ID `uk.co.gresearch` is setup on the legacy OSSRH host `oss.sonatype.org`