### PR TITLE
Allow specifying multiple paths for a ListingTable

### DIFF
--- a/datafusion-java/src/test/java/org/apache/arrow/datafusion/TestListingTable.java
+++ b/datafusion-java/src/test/java/org/apache/arrow/datafusion/TestListingTable.java
@@ -2,13 +2,17 @@ package org.apache.arrow.datafusion;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.junit.jupiter.api.Test;
@@ -140,6 +144,93 @@ public class TestListingTable {
         }
       }
       assertEquals(expectedResults.length, globalRow);
+    }
+  }
+
+  @Test
+  public void testParquetTimestampedStrings(@TempDir Path tempDir) throws Exception {
+    try (SessionContext context = SessionContexts.create();
+        BufferAllocator allocator = new RootAllocator()) {
+      Path dataDir = tempDir.resolve("data");
+      String schema =
+          "{\"namespace\": \"org.example\","
+              + "\"type\": \"record\","
+              + "\"name\": \"record_name\","
+              + "\"fields\": ["
+              + " {\"name\": \"id\", \"type\": \"long\"},"
+              + " {\"name\": \"timestamp\", \"type\": {\"type\": \"long\", \"logicalType\": \"timestamp-millis\"}},"
+              + " {\"name\": \"text\", \"type\": \"string\"}"
+              + " ]}";
+
+      Path parquetFilePath0 = dataDir.resolve("0.parquet");
+      Instant[] timestamps0 = {
+        Instant.parse("2022-04-04T00:00:00Z"),
+        Instant.parse("2022-05-04T00:00:00Z"),
+        Instant.parse("2022-06-06T00:00:00Z"),
+      };
+      ParquetWriter.writeParquet(
+          parquetFilePath0,
+          schema,
+          3,
+          (i, record) -> {
+            record.put("id", i + 1);
+            record.put("timestamp", (timestamps0[i].getEpochSecond() * 1_000));
+            record.put("text", String.format("Text%d", i + 1));
+          });
+
+      Path parquetFilePath1 = dataDir.resolve("1.parquet");
+      Instant[] timestamps1 = {
+        Instant.parse("2023-04-04T00:00:00Z"),
+        Instant.parse("2023-04-04T00:00:00Z"),
+        Instant.parse("2022-08-01T00:00:00Z"),
+      };
+      ParquetWriter.writeParquet(
+          parquetFilePath1,
+          schema,
+          3,
+          (i, record) -> {
+            record.put("id", i + 4);
+            record.put("timestamp", (timestamps1[i].getEpochSecond() * 1_000));
+            record.put("text", String.format("Text%d", i + 4));
+          });
+
+      Path[] filePaths = {parquetFilePath0, parquetFilePath1};
+
+      try (ParquetFormat format = new ParquetFormat();
+          ListingOptions listingOptions =
+              ListingOptions.builder(format).withFileExtension(".parquet").build();
+          ListingTableConfig tableConfig =
+              ListingTableConfig.builder(filePaths)
+                  .withListingOptions(listingOptions)
+                  .build(context)
+                  .join();
+          ListingTable listingTable = new ListingTable(tableConfig)) {
+        context.registerTable("test", listingTable);
+        try (ArrowReader reader =
+            context
+                .sql(
+                    "SELECT id,text FROM test WHERE ID IN (2, 3, 4) AND timestamp < '2023-01-01T00:00:00Z' ORDER BY id")
+                .thenComposeAsync(df -> df.collect(allocator))
+                .join()) {
+
+          Long[] expectedIds = {2L, 3L};
+          String[] expectedText = {"Text2", "Text3"};
+          List<Long> actualIds = new ArrayList<>();
+          List<String> actualText = new ArrayList<>();
+          int globalRow = 0;
+          VectorSchemaRoot root = reader.getVectorSchemaRoot();
+          while (reader.loadNextBatch()) {
+            BigIntVector idValues = (BigIntVector) root.getVector(0);
+            VarCharVector textValues = (VarCharVector) root.getVector(1);
+            for (int row = 0; row < root.getRowCount(); ++row, ++globalRow) {
+              actualIds.add(idValues.get(row));
+              actualText.add(new String(textValues.get(row), StandardCharsets.UTF_8));
+            }
+          }
+          assertArrayEquals(expectedIds, actualIds.toArray(new Long[0]));
+          assertArrayEquals(expectedText, actualText.toArray(new String[0]));
+        }
+      }
     }
   }
 }

--- a/datafusion-jni/src/listing_table_config.rs
+++ b/datafusion-jni/src/listing_table_config.rs
@@ -1,6 +1,6 @@
 use datafusion::datasource::listing::{ListingOptions, ListingTableConfig, ListingTableUrl};
 use datafusion::execution::context::SessionContext;
-use jni::objects::{JClass, JObject, JString};
+use jni::objects::{JClass, JObject, JObjectArray, JString};
 use jni::sys::jlong;
 use jni::JNIEnv;
 use tokio::runtime::Runtime;
@@ -13,27 +13,39 @@ pub extern "system" fn Java_org_apache_arrow_datafusion_ListingTableConfig_creat
     _class: JClass,
     runtime: jlong,
     context: jlong,
-    table_path: JString,
+    table_paths: JObjectArray,
     listing_options: jlong,
     callback: JObject,
 ) {
     let runtime = unsafe { &*(runtime as *const Runtime) };
     let context = unsafe { &*(context as *const SessionContext) };
 
-    let table_path: String = env
-        .get_string(&table_path)
-        .expect("Couldn't get Java table_path string")
-        .into();
-    let table_url = ListingTableUrl::parse(table_path);
-    let table_url = match table_url {
-        Ok(url) => url,
-        Err(err) => {
-            set_callback_result_error(&mut env, callback, &err);
-            return;
-        }
-    };
+    let mut table_urls: Vec<ListingTableUrl> = Vec::new();
+    let table_paths_length = env
+        .get_array_length(&table_paths)
+        .expect("Couldn't get array length of table_paths");
+    for i in 0..table_paths_length {
+        let table_path_str: JString = env
+            .get_object_array_element(&table_paths, i)
+            .expect("Couldn't get array string element")
+            .into();
+        let table_path: String = env
+            .get_string(&table_path_str)
+            .expect("Couldn't get native string source")
+            .into();
+        let table_url = ListingTableUrl::parse(table_path);
+        let table_url = match table_url {
+            Ok(url) => url,
+            Err(err) => {
+                set_callback_result_error(&mut env, callback, &err);
+                return;
+            }
+        };
+        table_urls.push(table_url);
+    }
+
     runtime.block_on(async {
-        let listing_table_config = ListingTableConfig::new(table_url);
+        let listing_table_config = ListingTableConfig::new_with_multi_paths(table_urls);
 
         let listing_table_config = match listing_options {
             0 => listing_table_config,


### PR DESCRIPTION
* Rather than relying on globbing or using all files in a directory, multiple paths can be specified explicitly (thanks to @m4rs-mt)
* Add a test that uses this, and also tests a more complex query with timestamps and string data